### PR TITLE
tag blacklisting

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -375,6 +375,10 @@ func (agg *BufferedAggregator) addSample(metricSample *metrics.MetricSample, tim
 	metricSample.Tags = util.SortUniqInPlace(filteredTags)
 	//log.Info("add sample::AFTER::TAGS:" + strings.Join(metricSample.Tags, ","))
 
+	if config.Datadog.GetBool("hostname.blacklist") {
+		metricSample.Host = ""
+	}
+
 	agg.statsdSampler.addSample(metricSample, timestamp)
 }
 

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -423,7 +423,6 @@ func (agg *BufferedAggregator) pushSeries(start time.Time, series metrics.Series
 func (agg *BufferedAggregator) sendSeries(start time.Time, series metrics.Series, waitForSerializer bool) {
 	recurrentSeriesLock.Lock()
 	// Adding recurrentSeries to the flushed ones
-	log.Info("LETS SEE")
 	for _, extra := range recurrentSeries {
 		if extra.Host == "" {
 			extra.Host = agg.hostname

--- a/testClient/test.py
+++ b/testClient/test.py
@@ -1,0 +1,14 @@
+from datadog import initialize, statsd
+import time
+
+options = {
+    'statsd_host':'127.0.0.1',
+    'statsd_port':8125
+}
+
+initialize(**options)
+
+while(1):
+  statsd.increment('example5_metric.increment', tags=["env:dev","dummy:123"])
+  statsd.decrement('example5_metric.decrement', tags=["env:dev","dummy:123"])
+  time.sleep(10)


### PR DESCRIPTION
### What does this PR do?

1. tag blacklisting - add a config to datadog.yaml with 
**key**: tags.blacklist & comma separated tag names

2. remove host from custom metrics (without sacrificing system metrics) 

### Motivation

cost reduction - combinatorial explosion in custom timeseries due to tags like hosts, plugin_id , ansible , security-group

### Testing:
1. Local testing against DD using test.py

2. Tried these config settings for blacklist:
a. Nothing in config
b. Only Key (no value) --> **tags.blacklist:**
c. **tags.blacklist: host,dummy**
d. **tags.blacklist: dummy**
e. **tags.blacklist: random**
f. **tags.blacklist: bad_formatting|test**

3. Tried these metrics from test.py:
a. "env","dummy:123",""
b. "env:dev","dummy:123"
c. "env:dev","host:123"

4. Tried hostname.blacklist: true & hostname.blacklist: false